### PR TITLE
Fix upload API path and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# CCU - ココフォリアログアップローダー
+
+このリポジトリはココフォリアのログ(html)を整形し、GitHub リポジトリへコミットできるツールです。
+
+## 使い方
+
+1. 本リポジトリをクローンします。
+2. `.env` を作成し、以下の環境変数を設定します。
+
+```
+GH_CLIENT_ID=your_github_oauth_client_id
+GH_CLIENT_SECRET=your_github_oauth_client_secret
+SESSION_SECRET=any_random_string
+WEBHOOK_SECRET=your_webhook_secret
+```
+
+3. [Vercel](https://vercel.com/) にデプロイするか、`vercel dev` コマンドでローカル開発サーバーを起動します。
+
+```
+npm install -g vercel
+vercel dev
+```
+
+4. ブラウザで `http://localhost:3000` を開き、画面の指示に従って操作します。
+   - GitHub と連携後、リポジトリ情報とコミット先パスを入力
+   - `log.html` をアップロードして整形し、「GitHub にコミット」ボタンでファイルを追加
+   - ローカル保存も可能です
+
+以上でアップロードされたログは GitHub Pages などで閲覧できます。

--- a/public/app.js
+++ b/public/app.js
@@ -25,11 +25,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // --- 1) OAuth開始 ---
   githubConnectBtn.addEventListener("click", () => {
-    window.location.href = "/auth/github";
+    // API ルートにリダイレクトして OAuth を開始
+    window.location.href = "/api/auth/github";
   });
 
   // 認証状態チェック
-  fetch("/api/auth/status", {
+  fetch("/api/auth-status", {
     credentials: "include",
     headers: { "X-CSRF-Token": getCsrfToken() }
   })
@@ -79,7 +80,7 @@ document.addEventListener("DOMContentLoaded", () => {
       formData.append("path", path);
       formData.append("linkText", linkText);
 
-      const res = await fetch("/api/user/upload", {
+      const res = await fetch("/api/upload", {
         method: "POST",
         credentials: "include",
         headers: { "X-CSRF-Token": getCsrfToken() },


### PR DESCRIPTION
## Summary
- correct the fetch URL to `/api/upload`
- document how to use the uploader
- route GitHub connect button to the correct API endpoint
- check auth status at the proper URL

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6869e18ca374832fbbfc0dfb6563b297