### PR TITLE
Add secure flag to auth cookie

### DIFF
--- a/api/auth/github-callback.js
+++ b/api/auth/github-callback.js
@@ -30,6 +30,7 @@ export default async function handler(req, res) {
       cookie.serialize("accessToken", tokenRes.data.access_token, {
         httpOnly: true,
         sameSite: "lax",
+        secure: true,
         path: "/",
       })
     );


### PR DESCRIPTION
## Summary
- ensure GitHub callback sets the `accessToken` cookie with `secure: true` so the token is only sent over HTTPS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a24cb0578832fb869c7eee12880c7