### PR TITLE
Add ES module type field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ccfolia-log-uploader",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vercel dev",
     "start": "vercel dev"


### PR DESCRIPTION
## Summary
- ensure Node treats `.js` files as ES modules

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686a26bfe218832f86dc51690da69970