### PR TITLE
Persist OAuth state on server

### DIFF
--- a/api/auth/github-callback.js
+++ b/api/auth/github-callback.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import cookie from "cookie";
+import { verifyState } from "../state-store.js";
 
 export default async function handler(req, res) {
   try {
@@ -11,7 +12,7 @@ export default async function handler(req, res) {
     // ← ここが旧来の split/map/Object.fromEntries ではなく…
     const cookies = cookie.parse(req.headers.cookie || "");
 
-    if (state !== cookies.oauth_state) {
+    if (state !== cookies.oauth_state || !verifyState(state)) {
       return res.status(403).send("Invalid state");
     }
 

--- a/api/auth/github.js
+++ b/api/auth/github.js
@@ -1,9 +1,14 @@
 import crypto from "crypto";
+import { saveState } from "../state-store.js";
 
 export default function handler(req, res) {
   const state = crypto.randomBytes(8).toString("hex");
-  // Vercel などの環境で state を一時保存する仕組みを用意してください
-  res.setHeader("Set-Cookie", `oauth_state=${state}; Path=/; HttpOnly; SameSite=Lax`);
+  // Save state server-side to verify after redirect
+  saveState(state);
+  res.setHeader(
+    "Set-Cookie",
+    `oauth_state=${state}; Path=/; HttpOnly; SameSite=Lax`
+  );
   const params = new URLSearchParams({
     client_id: process.env.GH_CLIENT_ID,
     scope: "repo",

--- a/api/state-store.js
+++ b/api/state-store.js
@@ -1,0 +1,13 @@
+const states = new Map();
+
+export function saveState(state) {
+  // expire in 10 minutes
+  states.set(state, Date.now() + 10 * 60 * 1000);
+}
+
+export function verifyState(state) {
+  const expire = states.get(state);
+  // remove state regardless of validity to prevent replay
+  states.delete(state);
+  return Boolean(expire && expire > Date.now());
+}


### PR DESCRIPTION
## Summary
- store OAuth `state` in a server-side map
- verify `state` in callback using the new store

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686a28492140832fae8eef1ded635f58