### PR TITLE
Improve GitHub auth UI

### DIFF
--- a/api/auth-status.js
+++ b/api/auth-status.js
@@ -1,6 +1,18 @@
-export default function handler(req, res) {
+import { Octokit } from "@octokit/rest";
+
+export default async function handler(req, res) {
   const cookies = Object.fromEntries(
     (req.headers.cookie || "").split("; ").map(c => c.split("="))
   );
-  res.json({ authenticated: Boolean(cookies.accessToken) });
+  const token = cookies.access_token;
+  if (!token) return res.json({ authenticated: false });
+
+  try {
+    const octokit = new Octokit({ auth: token });
+    const { data } = await octokit.rest.users.getAuthenticated();
+    return res.json({ authenticated: true, username: data.login });
+  } catch (err) {
+    console.error("Failed to fetch user info", err);
+    return res.json({ authenticated: true, username: null });
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -25,16 +25,61 @@
         GitHub リポジトリにコミット／ローカル保存できるツールです。
       </p>
 
-<div id="authSection">
-  <!-- ボタンではなくアンカーにする -->
-  <a
-    id="githubConnectBtn"
-    class="btn btn-dark"
-    href="/api/auth/github"
-  >
-    GitHub と連携
-  </a>
-</div>
+      <!-- ① GitHub連携セクション -->
+      <div class="card mb-4">
+        <div class="card-header">① GitHub 連携</div>
+        <div class="card-body">
+          <div id="authSection">
+            <button id="githubConnectBtn" class="btn btn-dark">
+              GitHub と連携
+            </button>
+          </div>
+          <p id="loginInfo" class="mt-2" style="display: none;"></p>
+          <div id="repoSettings" style="display: none;">
+            <div class="row mb-3">
+              <div class="col">
+                <input
+                  type="text"
+                  id="ownerInput"
+                  class="form-control"
+                  placeholder="リポジトリ所有者 (ユーザー名/Org)"
+                />
+              </div>
+              <div class="col">
+                <input
+                  type="text"
+                  id="repoInput"
+                  class="form-control"
+                  placeholder="リポジトリ名"
+                />
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="pathInput" class="form-label">コミット先パス</label>
+              <input
+                type="text"
+                id="pathInput"
+                class="form-control"
+                value="logs/test.html"
+              />
+            </div>
+            <div class="mb-3">
+              <button id="githubUploadBtn" class="btn btn-primary">
+                GitHub にコミット
+              </button>
+              <button
+                id="viewProjectBtn"
+                class="btn btn-secondary ms-2"
+                style="display: none;"
+              >
+                プロジェクト公開ページを開く
+              </button>
+            </div>
+            <div id="githubStatus" class="mt-2"></div>
+          </div>
+        </div>
+      </div>
+
       <!-- ② HTML整形・ローカル保存セクション -->
       <div class="card mb-4">
         <div class="card-header">② HTML 整形・ローカル保存</div>


### PR DESCRIPTION
## Summary
- restore GitHub integration form
- show logged-in GitHub username after authenticating
- fix auth-status API to read cookie and fetch user info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a3cc0ac40832fb5bd638b5c09fdae