### PR TITLE
Move commit controls, remove download

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -13,17 +13,23 @@ document.addEventListener("DOMContentLoaded", () => {
   const loginInfo        = document.getElementById("loginInfo");
   const ownerInput       = document.getElementById("ownerInput");
   const repoInput        = document.getElementById("repoInput");
+  const pathInput        = document.getElementById("pathInput");
   const viewProjectBtn   = document.getElementById("viewProjectBtn");
   const githubUploadBtn  = document.getElementById("githubUploadBtn");
   const githubStatus     = document.getElementById("githubStatus");
 
   const uploadHtml       = document.getElementById("uploadHtml");
   const formatBtn        = document.getElementById("formatBtn");
-  const downloadBtn      = document.getElementById("downloadBtn");
-  const filenameInput    = document.getElementById("filenameInput");
   const linknameInput    = document.getElementById("linknameInput");
   const formattedOutput  = document.getElementById("formattedOutput");
-  const listContainer    = document.getElementById("generatedList");
+
+  // リンク名入力に合わせてコミットパスを更新
+  const syncPath = () => {
+    const name = linknameInput.value.trim() || "test";
+    pathInput.value = `log/${name}.html`;
+  };
+  linknameInput.addEventListener("input", syncPath);
+  syncPath();
 
   // --- GitHub OAuth 開始 ---
   githubConnectBtn.addEventListener("click", () => {
@@ -75,7 +81,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const out   = formattedOutput.textContent;
     const owner = ownerInput.value.trim();
     const repo  = repoInput.value.trim();
-    const path  = document.getElementById("pathInput").value.trim();
+    const path  = pathInput.value.trim();
     const linkText = linknameInput.value.trim();
 
     if (!out) return alert("まずは「修正」ボタンで整形してください");
@@ -108,7 +114,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // --- HTML 整形・ローカル保存 ---
+  // --- HTML 整形 ---
   formatBtn.addEventListener("click", () => {
     if (!uploadHtml.files.length) return alert("整形したい HTML ファイルを選択してください");
     const reader = new FileReader();
@@ -122,49 +128,5 @@ document.addEventListener("DOMContentLoaded", () => {
     reader.readAsText(uploadHtml.files[0]);
   });
 
-  downloadBtn.addEventListener("click", () => {
-    const out      = formattedOutput.textContent;
-    const filename = filenameInput.value.trim() || "test.html";
-    const linkname = linknameInput.value.trim() || filename;
-    if (!out) return alert("まずは「修正」ボタンで整形してください");
 
-    const blob = new Blob([out], { type: "text/html" });
-    const a    = document.createElement("a");
-    a.href     = URL.createObjectURL(blob);
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(a.href);
-
-    const files = JSON.parse(localStorage.getItem("generatedFiles") || "[]");
-    const entry = { filename, linkname };
-    if (!files.some(f => f.filename === filename)) {
-      files.push(entry);
-      localStorage.setItem("generatedFiles", JSON.stringify(files));
-      appendToGeneratedList(entry);
-    }
-  });
-
-  // --- 作成済み一覧の初期表示 ---
-  if (listContainer) {
-    const files = JSON.parse(localStorage.getItem("generatedFiles") || "[]");
-    if (!files.length) {
-      const li = document.createElement("li");
-      li.className = "list-group-item";
-      li.textContent = "まだファイルが生成されていません。";
-      listContainer.appendChild(li);
-    } else {
-      files.forEach(appendToGeneratedList);
-    }
-  }
-
-  function appendToGeneratedList({ filename, linkname }) {
-    const li = document.createElement("li");
-    li.className = "list-group-item";
-    const a  = document.createElement("a");
-    a.href       = filename;
-    a.textContent = linkname || filename;
-    a.target      = "_blank";
-    li.appendChild(a);
-    listContainer.appendChild(li);
-  }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       <h1 class="mb-4">ココフォリアログアップローダー (CCU)</h1>
       <p>
         ローカルの log.html を検索除外タグ付きで整形し、
-        GitHub リポジトリにコミット／ローカル保存できるツールです。
+        GitHub リポジトリにコミットできるツールです。
       </p>
 
       <!-- ① GitHub連携セクション -->
@@ -64,26 +64,13 @@
               
               />
             </div>
-            <div class="mb-3">
-              <button id="githubUploadBtn" class="btn btn-primary">
-                GitHub にコミット
-              </button>
-              <button
-                id="viewProjectBtn"
-                class="btn btn-secondary ms-2"
-                style="display: none;"
-              >
-                プロジェクト公開ページを開く
-              </button>
-            </div>
-            <div id="githubStatus" class="mt-2"></div>
           </div>
         </div>
       </div>
 
-      <!-- ② HTML整形・ローカル保存セクション -->
+      <!-- ② HTML整形・アップロードセクション -->
       <div class="card mb-4">
-        <div class="card-header">② HTML 整形・ローカル保存</div>
+        <div class="card-header">② HTML 整形・アップロード</div>
         <div class="card-body">
           <div class="mb-3">
             <label for="uploadHtml" class="form-label"
@@ -115,12 +102,22 @@
             />
           </div>
           <button id="formatBtn" class="btn btn-secondary me-2">修正</button>
-          <button id="downloadBtn" class="btn btn-info">ローカル保存</button>
+          <button id="githubUploadBtn" class="btn btn-primary me-2">
+            GitHub にコミット
+          </button>
+          <button
+            id="viewProjectBtn"
+            class="btn btn-secondary"
+            style="display: none;"
+          >
+            ログ一覧ページを開く
+          </button>
           <pre
             id="formattedOutput"
             class="mt-3 border p-3"
             style="height: 150px; overflow: auto;"
           ></pre>
+          <div id="githubStatus" class="mt-2"></div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- update text to remove mention of local save
- move GitHub commit button to HTML formatting section
- rename the view button label
- remove local download logic from JS
- sync commit path with link name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d7b279c832f8b23f2928be2cd8d