### PR TITLE
Add numeric-only restriction to link name input

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -25,6 +25,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // リンク名入力に合わせてコミットパスを更新
   const syncPath = () => {
+    // 半角数字以外は除去
+    linknameInput.value = linknameInput.value.replace(/[^0-9]/g, "");
     const name = linknameInput.value.trim() || "test";
     pathInput.value = `log/${name}.html`;
   };

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,10 @@
               type="text"
               id="linknameInput"
               class="form-control"
-              placeholder="例: sample_scenario"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              title="半角数字のみ"
+              placeholder="例: 12345"
             />
           </div>
           <button id="formatBtn" class="btn btn-secondary me-2">修正</button>


### PR DESCRIPTION
## Summary
- restrict the link name input in the UI to accept only digits
- sanitize the input on change so non-digit characters are removed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a5161244c832fab8be271e84b78e1