### PR TITLE
Add GitHub Pages initialization

### DIFF
--- a/api/init.js
+++ b/api/init.js
@@ -1,0 +1,128 @@
+import { Octokit } from "@octokit/rest";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ ok: false, error: "Method Not Allowed" });
+  }
+
+  const cookies = Object.fromEntries(
+    (req.headers.cookie || "").split("; ").map(c => c.split("="))
+  );
+  const token = cookies.access_token;
+  if (!token) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+  const { owner, repo } = req.body || {};
+  if (!owner || !repo) {
+    return res.status(400).json({ ok: false, error: "Missing owner or repo" });
+  }
+
+  const octokit = new Octokit({ auth: token });
+
+  const INIT_INDEX = `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>GitHub Pages</title>
+</head>
+<body>
+  <h1>It works!</h1>
+</body>
+</html>`;
+
+  const WORKFLOW_YAML = `name: Deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build --if-present
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+`;
+
+  const PACKAGE_JSON = JSON.stringify(
+    {
+      name: "coc-github-io",
+      version: "1.0.0",
+      private: true,
+      description: "GitHub Pages site for coc.github.io",
+      scripts: {
+        build: "echo \"No build step\""
+      },
+      dependencies: {}
+    },
+    null,
+    2
+  );
+
+  const { data: repoInfo } = await octokit.repos.get({ owner, repo });
+  const branch = repoInfo.default_branch;
+  const { data: refData } = await octokit.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${branch}`,
+  });
+  const baseCommitSha = refData.object.sha;
+  const { data: baseCommit } = await octokit.git.getCommit({
+    owner,
+    repo,
+    commit_sha: baseCommitSha,
+  });
+
+  const files = [
+    { path: "index.html", content: INIT_INDEX },
+    { path: ".github/workflows/pages.yml", content: WORKFLOW_YAML },
+    { path: "package.json", content: PACKAGE_JSON },
+  ];
+
+  const treeItems = [];
+  for (const file of files) {
+    const { data: blob } = await octokit.git.createBlob({
+      owner,
+      repo,
+      content: Buffer.from(file.content, "utf8").toString("base64"),
+      encoding: "base64",
+    });
+    treeItems.push({ path: file.path, mode: "100644", type: "blob", sha: blob.sha });
+  }
+
+  const { data: newTree } = await octokit.git.createTree({
+    owner,
+    repo,
+    base_tree: baseCommit.tree.sha,
+    tree: treeItems,
+  });
+
+  const { data: newCommit } = await octokit.git.createCommit({
+    owner,
+    repo,
+    message: "Initial setup for GitHub Pages",
+    tree: newTree.sha,
+    parents: [baseCommitSha],
+  });
+
+  await octokit.git.updateRef({
+    owner,
+    repo,
+    ref: `heads/${branch}`,
+    sha: newCommit.sha,
+  });
+
+  res.json({ ok: true });
+}

--- a/public/app.js
+++ b/public/app.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const githubUploadBtn  = document.getElementById("githubUploadBtn");
   const githubStatus     = document.getElementById("githubStatus");
   const githubDisconnectBtn = document.getElementById("githubDisconnectBtn");
+  const initRepoBtn      = document.getElementById("initRepoBtn");
 
   const uploadHtml       = document.getElementById("uploadHtml");
   const formatBtn        = document.getElementById("formatBtn");
@@ -93,6 +94,35 @@ document.addEventListener("DOMContentLoaded", () => {
   }
   ownerInput.addEventListener("input", updateViewBtn);
   repoInput.addEventListener("input", updateViewBtn);
+
+  // --- 初期設定: GitHub Pages 用ファイル作成 ---
+  initRepoBtn.addEventListener("click", async () => {
+    const owner = ownerInput.value.trim();
+    const repo  = repoInput.value.trim();
+    if (!owner || !repo) return alert("リポジトリ情報を入力してください");
+
+    githubStatus.textContent = "初期設定中…";
+    try {
+      const res = await fetch("/api/init", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": getCsrfToken()
+        },
+        body: JSON.stringify({ owner, repo })
+      });
+      const result = await res.json();
+      if (result.ok) {
+        githubStatus.innerHTML = '<div class="alert alert-success">初期設定が完了しました</div>';
+      } else {
+        githubStatus.innerHTML = `<div class="alert alert-danger">エラー: ${result.error}</div>`;
+      }
+    } catch (err) {
+      console.error(err);
+      githubStatus.innerHTML = '<div class="alert alert-danger">通信エラーが発生しました</div>';
+    }
+  });
 
   // --- GitHub へのコミット ---
   githubUploadBtn.addEventListener("click", async () => {

--- a/public/index.html
+++ b/public/index.html
@@ -68,9 +68,12 @@
                 id="pathInput"
                 class="form-control"
                 value="log/test.html"
-              
+
               />
             </div>
+            <button id="initRepoBtn" class="btn btn-outline-primary mb-3">
+              初期設定
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `initRepoBtn` to allow creating GitHub Pages files
- create `/api/init.js` endpoint for initial setup
- show button in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ba74507d4832fa43847aa7d02a8c5