### PR TITLE
Fix GitHub OAuth redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ GitHub を準備する
 GitHub のアカウントがない場合は GitHub に登録します。
 画面右上の「＋」から「新しいリポジトリ」を作り、名前を決めます。
 
+GitHub OAuth アプリを登録する
+連携を自分の環境で使う場合は、GitHub の OAuth App に
+`https://<あなたのドメイン>/api/auth/github-callback`
+を Callback URL として登録し、同じ URL を `.env` の
+`AUTH_CALLBACK_URL` に設定してください。
+
 サイトを開く
 ブラウザで https://ccfolia-log-uploader.vercel.app/ を開きます。
 

--- a/api/auth/github.js
+++ b/api/auth/github.js
@@ -15,7 +15,9 @@ export default function handler(req, res) {
     })
   );
 
-  const redirectUri = `${req.headers["x-forwarded-proto"]}://${req.headers.host}/api/auth/github-callback`;
+  const redirectUri =
+    process.env.AUTH_CALLBACK_URL ||
+    `${req.headers["x-forwarded-proto"]}://${req.headers.host}/api/auth/github-callback`;
   const params = new URLSearchParams({
     client_id:    process.env.GH_CLIENT_ID,
     redirect_uri: redirectUri,


### PR DESCRIPTION
## Summary
- add environment variable support for GitHub OAuth callback URL
- document how to configure AUTH_CALLBACK_URL

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686bbbfbd81c832fb71a0bd63279b0bb