### PR TITLE
Fix missing Octokit import

### DIFF
--- a/api/init.js
+++ b/api/init.js
@@ -1,3 +1,5 @@
+import { Octokit } from "@octokit/rest";
+
 export default async function handler(req, res) {
   if (req.method !== "POST")
     return res.status(405).json({ ok: false, error: "Method Not Allowed" });


### PR DESCRIPTION
## Summary
- import Octokit in `api/init.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bc13bc548832fba765505387c4e60