### PR TITLE
Add repo creation and initialization buttons

### DIFF
--- a/api/create-repo.js
+++ b/api/create-repo.js
@@ -1,0 +1,33 @@
+import { Octokit } from "@octokit/rest";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST")
+    return res.status(405).json({ ok: false, error: "Method Not Allowed" });
+
+  const cookies = Object.fromEntries(
+    (req.headers.cookie || "").split("; ").map(c => c.split("="))
+  );
+  const token = cookies.access_token;
+  if (!token) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+  const { name, description } = req.body || {};
+  if (!name)
+    return res.status(400).json({ ok: false, error: "Missing repository name" });
+
+  const octokit = new Octokit({ auth: token });
+
+  try {
+    const { data: repo } = await octokit.rest.repos.createForAuthenticatedUser({
+      name,
+      description: description || "CCUログ用GitHub Pagesリポジトリ",
+      private: false,
+      auto_init: false,
+    });
+    return res.json({ ok: true, repo: repo.full_name });
+  } catch (err) {
+    console.error("create-repo error:", err);
+    return res
+      .status(500)
+      .json({ ok: false, error: "Failed to create repository" });
+  }
+}

--- a/api/init.js
+++ b/api/init.js
@@ -5,7 +5,6 @@ export default async function handler(req, res) {
     return res.status(405).json({ ok: false, error: "Method Not Allowed" });
   }
 
-  // 認証トークン取得
   const cookies = Object.fromEntries(
     (req.headers.cookie || "").split("; ").map(c => c.split("="))
   );
@@ -22,25 +21,27 @@ export default async function handler(req, res) {
   const octokit = new Octokit({ auth: token });
 
   try {
-    // リポジトリ情報取得
-    const { data: repoInfo } = await octokit.repos.get({ owner, repo });
-    const branch = repoInfo.default_branch;
-    console.log("init:", { owner, repo, branch });
+    // base commit info (handle empty repos)
+    const branch = "main";
+    let baseCommitSha = null;
+    let baseTreeSha = null;
+    try {
+      const { data: refData } = await octokit.git.getRef({
+        owner,
+        repo,
+        ref: `heads/${branch}`,
+      });
+      baseCommitSha = refData.object.sha;
+      const { data: baseCommit } = await octokit.git.getCommit({
+        owner,
+        repo,
+        commit_sha: baseCommitSha,
+      });
+      baseTreeSha = baseCommit.tree.sha;
+    } catch (err) {
+      if (err.status !== 404) throw err;
+    }
 
-    // 参照情報取得（修正箇所）
-    const { data: refData } = await octokit.git.getRef({
-      owner,
-      repo,
-      ref: `heads/${branch}`,
-    });
-    const baseCommitSha = refData.object.sha;
-    const { data: baseCommit } = await octokit.git.getCommit({
-      owner,
-      repo,
-      commit_sha: baseCommitSha,
-    });
-
-    // ファイル定義
     const INIT_INDEX = `<!DOCTYPE html>
 <html lang="ja">
 <head><meta charset="utf-8"><title>GitHub Pages</title></head>
@@ -79,21 +80,22 @@ jobs:
           publish_dir: ./public
 `;
     const PACKAGE_JSON = JSON.stringify({
-      name: "coc-github-io",
+      name: repo,
       version: "1.0.0",
       private: true,
-      description: "GitHub Pages site for coc.github.io",
+      description: "GitHub Pages site for " + repo,
       scripts: { build: "echo \"No build step\"" },
       dependencies: {},
     }, null, 2);
+    const README_MD = `# ${repo}\n\nCreated by CCU for GitHub Pages.`;
 
     const files = [
       { path: "index.html", content: INIT_INDEX },
       { path: ".github/workflows/pages.yml", content: WORKFLOW_YAML },
       { path: "package.json", content: PACKAGE_JSON },
+      { path: "README.md", content: README_MD },
     ];
 
-    // ブロブ→ツリー→コミット→参照更新
     const treeItems = [];
     for (const file of files) {
       const { data: blob } = await octokit.git.createBlob({
@@ -104,31 +106,41 @@ jobs:
       });
       treeItems.push({ path: file.path, mode: "100644", type: "blob", sha: blob.sha });
     }
+
     const { data: newTree } = await octokit.git.createTree({
       owner,
       repo,
-      base_tree: baseCommit.tree.sha,
+      base_tree: baseTreeSha || undefined,
       tree: treeItems,
     });
+
     const { data: newCommit } = await octokit.git.createCommit({
       owner,
       repo,
       message: "Initial setup for GitHub Pages",
       tree: newTree.sha,
-      parents: [baseCommitSha],
+      parents: baseCommitSha ? [baseCommitSha] : [],
     });
-    await octokit.git.updateRef({
-      owner,
-      repo,
-      ref: `heads/${branch}`,   // ← こちらも修正
-      sha: newCommit.sha,
-    });
+
+    if (baseCommitSha) {
+      await octokit.git.updateRef({
+        owner,
+        repo,
+        ref: `heads/${branch}`,
+        sha: newCommit.sha,
+      });
+    } else {
+      await octokit.git.createRef({
+        owner,
+        repo,
+        ref: `refs/heads/${branch}`,
+        sha: newCommit.sha,
+      });
+    }
 
     return res.json({ ok: true });
   } catch (err) {
-    console.error("❌ init error:", err);
-    return res
-      .status(err.status || 500)
-      .json({ ok: false, error: err.message });
+    console.error("init error:", err);
+    return res.status(err.status || 500).json({ ok: false, error: err.message });
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,21 @@
           >
             GitHub 連携解除
           </button>
+          <button
+            id="createRepoBtn"
+            class="btn btn-success ms-2"
+            style="display: none;"
+          >
+            リポジトリ作成
+          </button>
+
+          <button
+            id="initRepoBtn"
+            class="btn btn-outline-primary ms-2"
+            style="display: none;"
+          >
+            初期設定
+          </button>
           <div id="repoSettings" style="display: none;">
             <div class="mb-3">
               <input


### PR DESCRIPTION
## Summary
- add buttons for repository creation and initial setup
- wire buttons up in app.js
- add API route to create a repo
- update initialization route to include README and handle empty repositories

## Testing
- `npm test` *(fails: Missing script and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c8cfa2bc4832fa628fd9770cf9d99