### PR TITLE
Fix empty repo init

### DIFF
--- a/api/init.js
+++ b/api/init.js
@@ -39,7 +39,7 @@ export default async function handler(req, res) {
       });
       baseTreeSha = baseCommit.tree.sha;
     } catch (err) {
-      if (err.status === 404) {
+      if (err.status === 404 || err.status === 422) {
         // create initial README commit when repository is empty
         const { data: readmeBlob } = await octokit.git.createBlob({
           owner,


### PR DESCRIPTION
## Summary
- handle 422 error returned when initializing an empty repository

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_686ced4d8db8832fa9bc89db5480f36d