### PR TITLE
Handle 409 no-commit errors

### DIFF
--- a/api/create-and-init.js
+++ b/api/create-and-init.js
@@ -46,8 +46,9 @@ export default async function handler(req, res) {
         commit_sha: baseCommitSha,
       });
       baseTreeSha = baseCommit.tree.sha;
-    } catch (err) {
-      if (err.status === 404 || err.status === 422) {
+      } catch (err) {
+        // GitHub returns 409 when the repository has no commits yet
+        if (err.status === 404 || err.status === 422 || err.status === 409) {
         const { data: readmeBlob } = await octokit.git.createBlob({
           owner,
           repo,

--- a/api/init.js
+++ b/api/init.js
@@ -39,7 +39,8 @@ export default async function handler(req, res) {
       });
       baseTreeSha = baseCommit.tree.sha;
     } catch (err) {
-      if (err.status === 404 || err.status === 422) {
+      // GitHub returns 409 when the repository has no commits yet
+      if (err.status === 404 || err.status === 422 || err.status === 409) {
         // create initial README commit when repository is empty
         const { data: readmeBlob } = await octokit.git.createBlob({
           owner,


### PR DESCRIPTION
## Summary
- include GitHub 409 status when repositories have no commits
- add inline comment about the GitHub error code

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cf5ae89b4832fb7e4830a057b18ef