### PR TITLE
Add tab navigation with usage instructions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -26,6 +26,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const viewProjectBtn     = document.getElementById("viewProjectBtn");
   const githubStatus       = document.getElementById("githubStatus");
 
+  // タブ切り替え要素
+  const tabCCU = document.getElementById("tabCCU");
+  const tabUsage = document.getElementById("tabUsage");
+  const ccuContent = document.getElementById("ccuContent");
+  const usageContent = document.getElementById("usageContent");
+
   let ownerName = "";
 
   // リンク名 → path 同期
@@ -36,6 +42,27 @@ document.addEventListener("DOMContentLoaded", () => {
     };
     linknameInput.addEventListener("input", syncPath);
     syncPath();
+  }
+
+  // --- タブ切り替え ---
+  function activateTab(target) {
+    if (!tabCCU || !tabUsage || !ccuContent || !usageContent) return;
+    if (target === "ccu") {
+      tabCCU.classList.add("active");
+      tabUsage.classList.remove("active");
+      ccuContent.style.display = "block";
+      usageContent.style.display = "none";
+    } else {
+      tabUsage.classList.add("active");
+      tabCCU.classList.remove("active");
+      ccuContent.style.display = "none";
+      usageContent.style.display = "block";
+    }
+  }
+  if (tabCCU && tabUsage) {
+    tabCCU.addEventListener("click", () => activateTab("ccu"));
+    tabUsage.addEventListener("click", () => activateTab("usage"));
+    activateTab("ccu");
   }
 
   // --- GitHub OAuth 開始・解除 ---

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,17 @@
         GitHub リポジトリにコミットできるツールです。
       </p>
 
+      <ul class="nav nav-tabs mb-4" id="tabNav">
+        <li class="nav-item">
+          <button class="nav-link active" id="tabCCU" type="button">CCU</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" id="tabUsage" type="button">使い方</button>
+        </li>
+      </ul>
+
+      <div id="ccuContent">
+
       <!-- ① GitHub連携セクション -->
       <div class="card mb-4">
         <div class="card-header">① GitHub 連携</div>
@@ -134,6 +145,24 @@
             style="height: 150px; overflow: auto;"
           ></pre>
           <div id="githubStatus" class="mt-2"></div>
+        </div>
+
+      </div>
+      <!-- /#ccuContent -->
+      </div>
+
+      <div id="usageContent" style="display: none;">
+        <div class="card mb-4">
+          <div class="card-body">
+            <h2 class="h5 mb-3">使い方</h2>
+            <ol class="mb-0">
+              <li>GitHub と連携し、リポジトリを作成または指定します。</li>
+              <li>整形したい <code>log.html</code> を選択します。</li>
+              <li>シナリオ名とリンク名を入力し「修正」を押します。</li>
+              <li>「GitHub にコミット」ボタンでアップロードします。</li>
+              <li>完了後は「ログ一覧ページを開く」から確認できます。</li>
+            </ol>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- convert page to tab interface with "CCU" and "使い方" tabs
- show GitHub integration form on the CCU tab
- display usage instructions on the new "使い方" tab
- implement tab switching logic in `app.js`

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873927a3828832f9feb9de46a04604e