### PR TITLE
Add step for disabling GitHub email notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -291,6 +291,36 @@
                 いつでもアクセスできます。
               </li>
             </ol>
+
+            <hr />
+
+            <h3 class="h5 mt-4">4. GitHubからのメール通知をオフにする</h3>
+            <ol>
+              <li>
+                GitHub（<a href="https://github.com" target="_blank" rel="noopener">github.com</a>）にログインし、
+                画面右上のプロフィール写真をクリック。
+              </li>
+              <li>
+                メニューから <strong>Settings</strong>（設定）をクリック。
+              </li>
+              <li>
+                左側のメニューから <strong>Notifications</strong>（通知）を選択。
+              </li>
+              <li>
+                <strong>Email notification preferences</strong> の項目で、
+                <ul>
+                  <li>
+                    「Watching」「Participating」「Mention」など、受け取りたくない種類のチェックを外す。
+                  </li>
+                  <li>
+                    あるいは「Custom routing」欄で特定のリポジトリだけ振り分け設定し、不要なリポジトリの通知を止める。
+                  </li>
+                </ul>
+              </li>
+              <li>
+                ページ下部の <strong>Update notification settings</strong>（通知設定を更新）ボタンをクリックして保存。
+              </li>
+            </ol>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- document how to disable GitHub email notifications in `index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873a1883ea0832fb4e7cbec380996fa