### PR TITLE
Improve font handling and usage spacing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -228,8 +228,9 @@ document.addEventListener("DOMContentLoaded", () => {
     reader.onload = (e) => {
       let html = e.target.result;
       const robotsMeta = '<meta name="robots" content="noindex,nofollow">';
+      const fontStyle = '<style>* { font-family: sans-serif !important; }</style>';
       const norobotScript = '<script src="norobot.js"></scr' + 'ipt>';
-      html = html.replace(/<\/head>/i, robotsMeta + "\n" + norobotScript + "\n</head>");
+      html = html.replace(/<\/head>/i, robotsMeta + "\n" + fontStyle + "\n" + norobotScript + "\n</head>");
       formattedOutput.textContent = html;
     };
     reader.readAsText(uploadHtml.files[0]);

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,10 @@
         font-size: 87.5%; /* 16px * 0.875 = 14px */
       }
     }
+    #usageContent p,
+    #usageContent li {
+      line-height: 1.7;
+    }
   </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add a font override when formatting uploaded HTML
- widen line spacing in the usage section for readability

## Testing
- `npm --version`
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_6873a8500c7c832fa31bbea3d71f1c04